### PR TITLE
Add Show/Hide Password Feature to SignIn and SignUp Forms

### DIFF
--- a/client/src/pages/SignIn.jsx
+++ b/client/src/pages/SignIn.jsx
@@ -7,9 +7,11 @@ import {
   signInSuccess,
   signInFailure,
 } from "../redux/User/userSlice.js";
+import { FaEye, FaEyeSlash } from "react-icons/fa";
 
 export default function SignIn() {
   const [formData, setFormData] = useState({});
+  const [showPassword, setShowPassword] = useState(false);
   const { loading, error } = useSelector((state) => state.user);
   const navigate = useNavigate();
   const dispatch = useDispatch();

--- a/client/src/pages/SignIn.jsx
+++ b/client/src/pages/SignIn.jsx
@@ -58,13 +58,20 @@ export default function SignIn() {
           id="email"
           onChange={handleChange}
         />
+        <div className="relative">
         <input
-          type="password"
+          type={showPassword ? "text" : "password"}
           placeholder="Password" 
-          className="border rounded-lg p-3"
+          className="border rounded-lg p-3 pr-60"
           id="password"
           onChange={handleChange}
         />
+        <span 
+        className=" absolute right-3 top-1/2 transform -translate-y-1/2 cursor-pointer" 
+        onClick={() => setShowPassword(!showPassword)}>
+          {showPassword ? <FaEyeSlash /> : <FaEye />}
+        </span>
+        </div>
         <button
           disabled={loading}
           className="bg-slate-700 text-white p-3 rounded-lg uppercase hover:opacity-95 disabled:opacity-80"
@@ -76,7 +83,7 @@ export default function SignIn() {
       <div className="flex gap-2 mt-5">
         <p className="text-center text-sm text-slate-500">
           Don&apos;t have an account?{" "}
-          <Link to="/sign-up"> {/* Changed href to to */}
+          <Link to="/sign-up">
             <span className="text-blue-500">Sign Up</span>
           </Link>
         </p>

--- a/client/src/pages/SignIn.jsx
+++ b/client/src/pages/SignIn.jsx
@@ -13,12 +13,14 @@ export default function SignIn() {
   const { loading, error } = useSelector((state) => state.user);
   const navigate = useNavigate();
   const dispatch = useDispatch();
+
   const handleChange = (e) => {
     setFormData({
       ...formData,
       [e.target.id]: e.target.value,
     });
   };
+
   const handleSubmit = async (e) => {
     e.preventDefault();
     try {
@@ -42,6 +44,7 @@ export default function SignIn() {
       dispatch(signInFailure(error.message));
     }
   };
+
   return (
     <div className="p-3 max-w-lg mx-auto">
       <h1 className="text-3xl text-center font-semibold my-7">Sign In</h1>
@@ -51,12 +54,14 @@ export default function SignIn() {
           placeholder="Email"
           className="border rounded-lg p-3"
           id="email"
+          onChange={handleChange}
         />
         <input
           type="password"
-          placeholder="Username"
+          placeholder="Password" 
           className="border rounded-lg p-3"
           id="password"
+          onChange={handleChange}
         />
         <button
           disabled={loading}
@@ -69,7 +74,7 @@ export default function SignIn() {
       <div className="flex gap-2 mt-5">
         <p className="text-center text-sm text-slate-500">
           Don&apos;t have an account?{" "}
-          <Link href="/sign-up">
+          <Link to="/sign-up"> {/* Changed href to to */}
             <span className="text-blue-500">Sign Up</span>
           </Link>
         </p>

--- a/client/src/pages/SignUp.jsx
+++ b/client/src/pages/SignUp.jsx
@@ -7,12 +7,14 @@ export default function SignUp() {
   const [error, setError] = useState(null);
   const [loading, setLoading] = useState(false);
   const navigate = useNavigate();
+
   const handleChange = (e) => {
     setFormData({
       ...formData,
       [e.target.id]: e.target.value,
     });
   };
+
   const handleSubmit = async (e) => {
     e.preventDefault();
     try {
@@ -39,6 +41,7 @@ export default function SignUp() {
       setError(error.message);
     }
   };
+
   return (
     <div className="p-3 max-w-lg mx-auto">
       <h1 className="text-3xl text-center font-semibold my-7">Sign Up</h1>
@@ -48,18 +51,21 @@ export default function SignUp() {
           placeholder="Username"
           className="border rounded-lg p-3"
           id="username"
+          onChange={handleChange}
         />
         <input
           type="email"
           placeholder="Email"
           className="border rounded-lg p-3"
           id="email"
+          onChange={handleChange}
         />
         <input
           type="password"
-          placeholder="Username"
+          placeholder="Password"
           className="border rounded-lg p-3"
           id="password"
+          onChange={handleChange}
         />
         <button
           disabled={loading}
@@ -72,8 +78,10 @@ export default function SignUp() {
       <div className="flex gap-2 mt-5">
         <p className="text-center text-sm text-slate-500">
           Already have an account?{" "}
-          <Link href="/sign-in">
-            <span className="text-blue-500">Sign In</span>
+          <Link to="/sign-in">
+            <span className="text-blue-500 hover:text-blue-600 cursor-pointer">
+              Sign In
+            </span>
           </Link>
         </p>
       </div>

--- a/client/src/pages/SignUp.jsx
+++ b/client/src/pages/SignUp.jsx
@@ -1,9 +1,11 @@
 import { useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import OAuth from "../components/OAuth.jsx";
+import { FaEye, FaEyeSlash } from "react-icons/fa";
 
 export default function SignUp() {
   const [formData, setFormData] = useState({});
+  const [showPassword, setShowPassword] = useState(false);
   const [error, setError] = useState(null);
   const [loading, setLoading] = useState(false);
   const navigate = useNavigate();
@@ -60,13 +62,21 @@ export default function SignUp() {
           id="email"
           onChange={handleChange}
         />
+        <div className="relative">
         <input
-          type="password"
-          placeholder="Password"
-          className="border rounded-lg p-3"
-          id="password"
-          onChange={handleChange}
-        />
+            type={showPassword ? "text" : "password"} 
+            placeholder="Password"
+            className="border rounded-lg p-3 pr-10" 
+            id="password"
+            onChange={handleChange}
+          />
+          <span
+            className="absolute right-3 top-1/2 transform -translate-y-1/2 cursor-pointer"
+            onClick={() => setShowPassword(!showPassword)}
+          >
+            {showPassword ? <FaEyeSlash /> : <FaEye />}
+          </span>
+        </div>
         <button
           disabled={loading}
           className="bg-slate-700 text-white p-3 rounded-lg uppercase hover:opacity-95 disabled:opacity-80"


### PR DESCRIPTION
    Added the show/hide password functionality to both SignIn and SignUp components.
    Integrated FaEye and FaEyeSlash icons to toggle password visibility.
    Positioned the icons inside the password input fields on the right side.

Changes:

    SignIn.jsx: Added a password visibility toggle icon inside the password input field.
    SignUp.jsx: Added a password visibility toggle icon inside the password input field.